### PR TITLE
Add pyramid pipeline.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,10 @@ make flow_ref
 | April 14 | Working OpenCV reference and testing harness                  |  ✔️   |
 | April 25 | **[Checkpoint]** Working implementation in C++                |  ✔️   |
 | April 27 | Cleaned up and optimized C++ version                          |  ✔️   |
-| May 1    | Working implementation in CUDA                                |      |
-| May 5    | CUDA implementation with same performance as C++ version      |      |
-| May 8    | Achieve performance better than published in [1]              |      |
+| May 1    | Working implementation in CUDA                                |  ✔️   |
+| May 2    | CUDA implementation with same performance as C++ version      |  ✔️   |
+| May 4    | Realtime performance (~30fps / < 33ms)                        |  ✔️   |
+| May 8    | Super-realtime performance (~30fps / < 10ms)                  |      |
 | May 9    | Running on example drone footage                              |      |
 | May 11   | Final writeup and demo preparation                            |      |
 | May 11   | (_Reach_) Hardware hooked up to drone                         |      |

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -45,6 +45,7 @@ set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS}; -g -std=c++11 -arch=compute_61 -code=sm_
 set(KERNELS
   kernels/warmup.cpp
   kernels/sobel.cpp
+  kernels/pyramid.cpp
   kernels/resizeGrad.cpp
   kernels/resize.cpp)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -70,9 +70,9 @@ target_link_libraries(flow ${OpenCV_LIBS})
 
 # CUDA sandbox
 set(SANDBOX_FILES
-  # sandbox/process_sobel.cpp
-  #sandbox/process_resize.cpp
-  sandbox/process_resizeGrad.cpp
+  sandbox/process_sobel.cpp
+  # sandbox/process_resize.cpp
+  # sandbox/process_resizeGrad.cpp
   # sandbox/RgbMatTest.cpp
   sandbox/sandbox.cpp)
 cuda_add_executable(sandbox ${COMMON} ${KERNELS} ${SANDBOX_FILES})

--- a/src/kernels/pyramid.cpp
+++ b/src/kernels/pyramid.cpp
@@ -125,6 +125,7 @@ namespace cu {
     // For every finer level, resize and apply the gradients
     ////////////////////////////////////////////////////////////////////////////////////////////////
 
+
     for (int i = 1; i < nLevels; i++) {
 
       // Get the new size
@@ -175,6 +176,10 @@ namespace cu {
       Is[i].create(dstRect.height, dstRect.width, CV_32FC3);
       Ixs[i].create(dstRect.height, dstRect.width, CV_32FC3);
       Iys[i].create(dstRect.height, dstRect.width, CV_32FC3);
+
+      std::cout << "Is[" << i << "]: "  << Is[i].size() << " channels: " << Is[i].channels()
+        << " type: " << Is[i].type() << std::endl;
+
       compute_time += calc_print_elapsed("host alloc", start_host_alloc);
 
       // Copy over data

--- a/src/kernels/pyramid.cpp
+++ b/src/kernels/pyramid.cpp
@@ -1,0 +1,200 @@
+/**
+ * Implements pyramid construction as a kernel.
+ */
+
+// System
+#include <iostream>
+#include <chrono>
+#include <string>
+#include <stdexcept>
+
+// OpenCV
+#include <opencv2/opencv.hpp>
+
+// CUDA
+#include <cuda.h>
+#include <cuda_runtime.h>
+
+// NVIDIA Perf Primitives
+#include <nppi.h>
+#include <nppi_filtering_functions.h>
+
+// Local
+#include "../common/Exceptions.h"
+#include "../common/timer.h"
+
+#include "pyramid.h"
+
+using namespace timer;
+
+namespace cu {
+
+  void constructImgPyramids(
+      const cv::Mat& I,
+      cv::Mat* Is, cv::Mat* Ixs, cv::Mat* Iys,
+      int nLevels) {
+
+    // Timing
+    auto start_total = now();
+    double compute_time = 0.0;
+
+    // CV_32FC3 is made up of RGB floats
+    int channels = 3;
+    size_t elemSize = channels * sizeof(float);
+
+    // Setup
+    Is[0] = I.clone();
+
+    cv::Size sz = I.size();
+    int width   = sz.width;
+    int height  = sz.height;
+
+    unsigned int nSrcStep = width * elemSize;
+
+    // Gradient params
+    NppiBorderType eBorderType = NPP_BORDER_REPLICATE;
+    NppiSize  oSize   = { width, height };
+    NppiPoint oOffset = { 0, 0 };
+    NppiSize  oROI    = { width, height };
+
+    // Resize params
+    int eInterpolation = NPPI_INTER_LINEAR;    // Linear interpolation
+    double scaleX = 0.5;
+    double scaleY = 0.5;
+    double shiftX = 0.0;
+    double shiftY = 0.0;
+
+    std::cout << "[start] constructImgPyramids: processing "
+      << width << "x" << height << " image" << std::endl;
+
+    // Allocate device memory
+    auto start_cuda_malloc = now();
+    Npp32f *pDeviceI, *pDeviceIx, *pDeviceIy, *pDeviceTmp;
+
+    checkCudaErrors( cudaMalloc((void**) &pDeviceI,   width * height * elemSize) );
+    checkCudaErrors( cudaMalloc((void**) &pDeviceIx,  width * height * elemSize) );
+    checkCudaErrors( cudaMalloc((void**) &pDeviceIy,  width * height * elemSize) );
+    checkCudaErrors( cudaMalloc((void**) &pDeviceTmp, width * height * elemSize) );
+
+    calc_print_elapsed("cudaMalloc", start_cuda_malloc);
+
+    // Copy over initial image
+    auto start_memcpy_hd = now();
+
+    checkCudaErrors(
+        cudaMemcpy(pDeviceI, (float*) Is[0].data, width * height * elemSize, cudaMemcpyHostToDevice) );
+
+    calc_print_elapsed("cudaMemcpy I[0] H->D", start_memcpy_hd);
+
+    ////////////////////////////////////////////////////////////////////////////////////////////////
+    // Apply first gradients to Is[0]
+    ////////////////////////////////////////////////////////////////////////////////////////////////
+
+    // dx's
+    auto start_dx = now();
+    NPP_CHECK_NPP(
+        nppiFilterSobelHorizBorder_32f_C3R (
+          pDeviceI, nSrcStep, oSize, oOffset,
+          pDeviceIx, nSrcStep, oROI, eBorderType) );
+    compute_time += calc_print_elapsed("sobel: Ixs[0]", start_dx);
+
+    auto start_cp_dx = now();
+    Ixs[0].create(height, width, CV_32FC3);
+    checkCudaErrors(
+        cudaMemcpy(Ixs[0].data, pDeviceIx,
+          width * height * elemSize, cudaMemcpyDeviceToHost) );
+    compute_time += calc_print_elapsed("Ixs[0] cudaMemcpy D->H", start_cp_dx);
+
+    // dy's
+    auto start_dy = now();
+    NPP_CHECK_NPP(
+        nppiFilterSobelVertBorder_32f_C3R (
+          pDeviceI, nSrcStep, oSize, oOffset,
+          pDeviceIy, nSrcStep, oROI, eBorderType) );
+    compute_time += calc_print_elapsed("sobel: Iys[0]", start_dy);
+
+    auto start_cp_dy = now();
+    Iys[0].create(height, width, CV_32FC3);
+    checkCudaErrors(
+        cudaMemcpy(Iys[0].data, pDeviceIy,
+          width * height * elemSize, cudaMemcpyDeviceToHost) );
+    compute_time += calc_print_elapsed("Iys[0] cudaMemcpy D->H", start_cp_dy);
+
+
+    ////////////////////////////////////////////////////////////////////////////////////////////////
+    // For every finer level, resize and apply the gradients
+    ////////////////////////////////////////////////////////////////////////////////////////////////
+
+    for (int i = 1; i < nLevels; i++) {
+
+      // Get the new size
+      NppiRect srcRect = { 0, 0, width, height };
+      NppiRect dstRect;
+      NPP_CHECK_NPP(
+          nppiGetResizeRect (srcRect, &dstRect, scaleX, scaleY, shiftX, shiftY, eInterpolation) );
+
+      std::cout << "constructImgPyramids level " << i << ": "
+        << dstRect.width << "x" << dstRect.height << std::endl;
+
+      int nDstStep = dstRect.width * elemSize;
+
+      // Resize I => Tmp
+      NPP_CHECK_NPP(
+          nppiResizeSqrPixel_32f_C3R (
+            pDeviceI, oSize, nSrcStep, srcRect,
+            pDeviceTmp, nDstStep, dstRect,
+            scaleX, scaleY, shiftX, shiftY, eInterpolation) );
+
+      // Put the resized image back into I
+      std::swap(pDeviceI, pDeviceTmp);
+
+      // And update the dimensions
+      nSrcStep = nDstStep;
+      width = dstRect.width; height = dstRect.height;
+      oSize.width = width; oSize.height = height;
+      oROI.width  = width; oROI.height  = height;
+
+      // dx's
+      auto start_dx = now();
+      NPP_CHECK_NPP(
+          nppiFilterSobelHorizBorder_32f_C3R (
+            pDeviceI,  nSrcStep, oSize, oOffset,
+            pDeviceIx, nSrcStep, oROI, eBorderType) );
+      compute_time += calc_print_elapsed("sobel: Ixs[i]", start_dx);
+
+      // dy's
+      auto start_dy = now();
+      NPP_CHECK_NPP(
+          nppiFilterSobelVertBorder_32f_C3R (
+            pDeviceI, nSrcStep, oSize, oOffset,
+            pDeviceIy, nSrcStep, oROI, eBorderType) );
+      compute_time += calc_print_elapsed("sobel: Iys[i]", start_dy);
+
+      // Allocate host destinations
+      auto start_host_alloc = now();
+      Is[i].create(dstRect.height, dstRect.width, CV_32FC3);
+      Ixs[i].create(dstRect.height, dstRect.width, CV_32FC3);
+      Iys[i].create(dstRect.height, dstRect.width, CV_32FC3);
+      compute_time += calc_print_elapsed("host alloc", start_host_alloc);
+
+      // Copy over data
+      auto start_cp = now();
+      checkCudaErrors(
+          cudaMemcpy(Is[i].data, pDeviceI,
+            dstRect.width * dstRect.height * elemSize, cudaMemcpyDeviceToHost) );
+      checkCudaErrors(
+          cudaMemcpy(Ixs[i].data, pDeviceIx,
+            dstRect.width * dstRect.height * elemSize, cudaMemcpyDeviceToHost) );
+      checkCudaErrors(
+          cudaMemcpy(Iys[i].data, pDeviceIy,
+            dstRect.width * dstRect.height * elemSize, cudaMemcpyDeviceToHost) );
+      compute_time += calc_print_elapsed("pyramid cudaMemcpy D->H", start_cp);
+
+    }
+
+    calc_print_elapsed("total time", start_total);
+    std::cout << "[done] constructImgPyramids: primmary compute time: " << compute_time  << std::endl;
+  }
+
+}
+

--- a/src/kernels/pyramid.h
+++ b/src/kernels/pyramid.h
@@ -1,0 +1,38 @@
+/**
+ * Implements pyramid construction as a kernel
+ */
+
+#ifndef __KERNEL_PYRAMID_H__
+#define __KERNEL_PYRAMID_H__
+
+// System
+#include <iostream>
+#include <chrono>
+#include <string>
+#include <stdexcept>
+
+// OpenCV
+#include <opencv2/opencv.hpp>
+
+// CUDA
+#include <cuda.h>
+#include <cuda_runtime.h>
+
+// NVIDIA Perf Primitives
+#include <nppi.h>
+#include <nppi_filtering_functions.h>
+
+// Local
+#include "../common/timer.h"
+#include "../sandbox/process.h"
+
+namespace cu {
+
+  void constructImgPyramids(
+      const cv::Mat& I,
+      cv::Mat* Is, cv::Mat* Ixs, cv::Mat* Iys,
+      int nLevels);
+
+}
+
+#endif // end __KERNEL_PYRAMID_H__

--- a/src/kernels/sobel.cpp
+++ b/src/kernels/sobel.cpp
@@ -124,22 +124,17 @@ namespace cu {
 
     auto start_memcpy_dh = now();
 
-
     // Copy result to host
-    float* pHostDst = new float[width * height * channels];
+    dest.create(height, width, CV_32FC3);
+    float* pHostDst = (float*) dest.data;
 
     checkCudaErrors(
         cudaMemcpy(pHostDst, pDeviceDst, width * height * elemSize, cudaMemcpyDeviceToHost) );
 
     total_time += calc_print_elapsed("cudaMemcpy H<-D", start_memcpy_dh);
 
-    cv::Mat dest_wrapper(height, width, CV_32FC3, pHostDst);
-    dest_wrapper.copyTo(dest);
-
     cudaFree((void*) pDeviceSrc);
     cudaFree((void*) pDeviceDst);
-
-    delete[] pHostDst;
 
     std::cout << "[done] sobel" << std::endl;
     std::cout << "  primary compute time: " << compute_time << " (ms)" << std::endl;

--- a/src/kernels/sobel.cpp
+++ b/src/kernels/sobel.cpp
@@ -127,8 +127,13 @@ namespace cu {
         // : nppiFilterPrewittVertBorder_32f_C3R  (pDeviceSrc, nSrcStep, oSrcSize, oSrcOffset, pDeviceDst, nDstStep, oSizeROI, eBorderType)
 
         // Custom row filter
-        ? nppiFilterRowBorder_32f_C3R    (pDeviceSrc, nSrcStep, oSrcSize, oSrcOffset, pDeviceDst, nDstStep, oSizeROI, pDeviceKernel, nMaskSize, nAnchor, eBorderType)
-        : nppiFilterColumnBorder_32f_C3R (pDeviceSrc, nSrcStep, oSrcSize, oSrcOffset, pDeviceDst, nDstStep, oSizeROI, pDeviceKernel, nMaskSize, nAnchor, eBorderType)
+        ? nppiFilterRowBorder_32f_C3R (
+          pDeviceSrc, nSrcStep, oSrcSize, oSrcOffset,
+          pDeviceDst, nDstStep, oSizeROI, pDeviceKernel, nMaskSize, nAnchor, eBorderType)
+
+        : nppiFilterColumnBorder_32f_C3R (
+          pDeviceSrc, nSrcStep, oSrcSize, oSrcOffset,
+          pDeviceDst, nDstStep, oSizeROI, pDeviceKernel, nMaskSize, nAnchor, eBorderType)
 
         // Sobel with mask
         // ? nppiFilterSobelHorizMaskBorder_32f_C1R (pDeviceSrc, nSrcStep, oSrcSize, oSrcOffset, pDeviceDst, nDstStep, oSizeROI, NPP_MASK_SIZE_1_X_3, eBorderType)

--- a/src/kernels/sobel.cpp
+++ b/src/kernels/sobel.cpp
@@ -155,8 +155,6 @@ namespace cu {
     // Only for custom row/col filter
     cudaFree((void*) pDeviceKernel);
 
-    delete[] pHostDst;
-
     std::cout << "[done] sobel" << std::endl;
     std::cout << "  primary compute time: " << compute_time << " (ms)" << std::endl;
     std::cout << "  total compute time:   " << compute_time + total_time << " (ms)" << std::endl;

--- a/src/oflow.cpp
+++ b/src/oflow.cpp
@@ -76,25 +76,9 @@ namespace OFC {
     struct timeval start_time, end_time;
     gettimeofday(&start_time, NULL);
 
-    // // Construct image and gradient pyramides
-    // for (int i = 0; i <= op.coarsest_scale; ++i)  {
-    //   // At finest scale: copy directly, for all other: downscale previous scale by .5
-    //   if (i == 0) {
-    //     I0_mats[i] = I0.clone();
-    //     I1_mats[i] = I1.clone();
-
-    //     cu::sobel(I0_mats[i], I0x_mats[i], CV_32F, 1, 0, 1, 1, 0, cv::BORDER_DEFAULT);
-    //     cu::sobel(I0_mats[i], I0y_mats[i], CV_32F, 0, 1, 1, 1, 0, cv::BORDER_DEFAULT);
-    //     cu::sobel(I1_mats[i], I1x_mats[i], CV_32F, 1, 0, 1, 1, 0, cv::BORDER_DEFAULT);
-    //     cu::sobel(I1_mats[i], I1y_mats[i], CV_32F, 0, 1, 1, 1, 0, cv::BORDER_DEFAULT);
-    //   } else {
-    //     cu::resizeGrad(I0_mats[i-1], I0_mats[i], I0x_mats[i], I0y_mats[i], .5, .5);
-    //     cu::resizeGrad(I1_mats[i-1], I1_mats[i], I1x_mats[i], I1y_mats[i], .5, .5);
-    //   }
-    // }
-
-    cu::constructImgPyramids(I0, I0_mats, I0x_mats, I0y_mats, op.coarsest_scale);
-    cu::constructImgPyramids(I1, I1_mats, I1x_mats, I1y_mats, op.coarsest_scale);
+    // Construct image and gradient pyramides
+    cu::constructImgPyramids(I0, I0_mats, I0x_mats, I0y_mats, op.coarsest_scale + 1);
+    cu::constructImgPyramids(I1, I1_mats, I1x_mats, I1y_mats, op.coarsest_scale + 1);
 
     auto start_pad = now();
 

--- a/src/oflow.cpp
+++ b/src/oflow.cpp
@@ -22,6 +22,7 @@
 #include "kernels/resize.h"
 #include "kernels/resizeGrad.h"
 #include "kernels/sobel.h"
+#include "kernels/pyramid.h"
 #include "common/RgbMat.h"
 #include "common/timer.h"
 
@@ -75,22 +76,25 @@ namespace OFC {
     struct timeval start_time, end_time;
     gettimeofday(&start_time, NULL);
 
-    // Construct image and gradient pyramides
-    for (int i = 0; i <= op.coarsest_scale; ++i)  {
-      // At finest scale: copy directly, for all other: downscale previous scale by .5
-      if (i == 0) {
-        I0_mats[i] = I0.clone();
-        I1_mats[i] = I1.clone();
+    // // Construct image and gradient pyramides
+    // for (int i = 0; i <= op.coarsest_scale; ++i)  {
+    //   // At finest scale: copy directly, for all other: downscale previous scale by .5
+    //   if (i == 0) {
+    //     I0_mats[i] = I0.clone();
+    //     I1_mats[i] = I1.clone();
 
-        cu::sobel(I0_mats[i], I0x_mats[i], CV_32F, 1, 0, 1, 1, 0, cv::BORDER_DEFAULT);
-        cu::sobel(I0_mats[i], I0y_mats[i], CV_32F, 0, 1, 1, 1, 0, cv::BORDER_DEFAULT);
-        cu::sobel(I1_mats[i], I1x_mats[i], CV_32F, 1, 0, 1, 1, 0, cv::BORDER_DEFAULT);
-        cu::sobel(I1_mats[i], I1y_mats[i], CV_32F, 0, 1, 1, 1, 0, cv::BORDER_DEFAULT);
-      } else {
-        cu::resizeGrad(I0_mats[i-1], I0_mats[i], I0x_mats[i], I0y_mats[i], .5, .5);
-        cu::resizeGrad(I1_mats[i-1], I1_mats[i], I1x_mats[i], I1y_mats[i], .5, .5);
-      }
-    }
+    //     cu::sobel(I0_mats[i], I0x_mats[i], CV_32F, 1, 0, 1, 1, 0, cv::BORDER_DEFAULT);
+    //     cu::sobel(I0_mats[i], I0y_mats[i], CV_32F, 0, 1, 1, 1, 0, cv::BORDER_DEFAULT);
+    //     cu::sobel(I1_mats[i], I1x_mats[i], CV_32F, 1, 0, 1, 1, 0, cv::BORDER_DEFAULT);
+    //     cu::sobel(I1_mats[i], I1y_mats[i], CV_32F, 0, 1, 1, 1, 0, cv::BORDER_DEFAULT);
+    //   } else {
+    //     cu::resizeGrad(I0_mats[i-1], I0_mats[i], I0x_mats[i], I0y_mats[i], .5, .5);
+    //     cu::resizeGrad(I1_mats[i-1], I1_mats[i], I1x_mats[i], I1y_mats[i], .5, .5);
+    //   }
+    // }
+
+    cu::constructImgPyramids(I0, I0_mats, I0x_mats, I0y_mats, op.coarsest_scale);
+    cu::constructImgPyramids(I1, I1_mats, I1x_mats, I1y_mats, op.coarsest_scale);
 
     auto start_pad = now();
 


### PR DESCRIPTION
Use a single kernel for construct pyramids (except for the padding part). Uses the more accurate, row/col gradient filter. Still uses `cv::Mat`.